### PR TITLE
Made watchlistContains public

### DIFF
--- a/OddSDK/Info.plist
+++ b/OddSDK/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1200</string>
+	<string>1201</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/OddSDK/OddViewer.swift
+++ b/OddSDK/OddViewer.swift
@@ -163,7 +163,7 @@ public class OddViewer {
     }
   }
   
-  func watchlistContains(mediaObject: OddMediaObject) -> Bool {
+  public func watchlistContains(mediaObject: OddMediaObject) -> Bool {
     guard let type = mediaObject.mediaObjectType,
       let id = mediaObject.id else { return false }
     let item = OddRelationship(id: id, mediaObjectType: type)


### PR DESCRIPTION
Title says it all, made the OddViewer watchlistContainer function public to easily access it when in Video view controller and know if a specific video is toggled on (already on watch list) or not.